### PR TITLE
Add indexer object to config defaults

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -72,7 +72,8 @@ export default defineNuxtModule<ModuleOptions>({
       indexName: '',
       include: () => true,
       meta: ['title', 'description']
-    }
+    },
+    indexer: {}
   },
   setup (options, nuxt) {
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))


### PR DESCRIPTION
Added empty indexer object to defaults to prevent error on startup on line 153 when no indexer is present in nuxt.config.ts

I noticed when upgrading to 1.0.0 that the module wouldn't load unless an indexer object was present in nuxt.config, giving the following error:
 Cannot start nuxt:  Cannot convert undefined or null to object    
  at Function.keys (<anonymous>)
  at setup (/.../node_modules/@nuxtjs/algolia/dist/module.mjs:174:16)


## Types of changes
- [ x ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This fixes the error described above. I means you don't need an indexer object in the nuxt.config when one isn't needed.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
