### PR TITLE
fix: don't import docsearch css for server build

### DIFF
--- a/src/runtime/components/AlgoliaDocSearch.vue
+++ b/src/runtime/components/AlgoliaDocSearch.vue
@@ -65,7 +65,7 @@ const initialize = async (userOptions: DocSearchOptions) => {
     // @ts-ignore
     import(/* webpackChunkName: "docsearch" */ '@docsearch/js'),
     // @ts-ignore
-    import(/* webpackChunkName: "docsearch" */ '@docsearch/css')
+    process.client && import(/* webpackChunkName: "docsearch" */ '@docsearch/css')
   ]).then(([docsearch]) => docsearch.default)
 
   // TODO: Maybe bind this with @nuxt/i18n ?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
See https://github.com/nuxt/framework/issues/6813.

These lines:
https://github.com/nuxt-community/algolia-module/blob/449fceac98378c00f03f5ff92589a466ed83d356/src/runtime/components/AlgoliaDocSearch.vue#L63-L69

are transformed in the server build to

```js
      const docsearch = await Promise.all([
        import(
          /* webpackChunkName: "docsearch" */
          "./_nuxt/index.d1f4b1da.js"
        ),
        import(
          /* webpackChunkName: "docsearch" */
          "./_nuxt/style.1f98b5b0.js"
        )
      ]).then(([docsearch2]) => docsearch2.default);
```

... but the css import (the second one) is not emitted in the server build.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
